### PR TITLE
Pin spaCy to v2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy
+spacy>=2.1.0,<2.2.0
 tqdm
 ray
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.1.0/en_core_web_sm-2.1.0.tar.gz


### PR DESCRIPTION
Hey,

Came across your project on Reddit when I was posting the v2.2 release. v2.2 won't be compatible with the model you're linking in the requirements.txt, so users will get installation errors now that v2.2 is out.

I've pinned to v2.1 as that's what you tested with. I'm sure v2.2 will work fine too though.

For parallel processing, the new `DocBin` class might be helpful for you: https://spacy.io/usage/saving-loading#docs